### PR TITLE
Add Apify CLI Homebrew formula

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+end_of_line = lf
+
+[{*.yaml, *.yml, *.rb}]
+indent_size = 2

--- a/.github/scripts/update_formula.sh
+++ b/.github/scripts/update_formula.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+PACKAGE_NAME=$1
+PACKAGE_VERSION=$2
+
+if [[ "$#" -ne 2 ]]; then
+    echo "Usage: $0 package-name package-version"
+    exit 1;
+fi
+
+# Run in the Formula directory
+cd "$(dirname "$0")"/../../Formula
+
+PACKAGE_DEFINITION_URL="https://registry.npmjs.org/${PACKAGE_NAME}/${PACKAGE_VERSION}"
+
+# It can happen that the package is not available right after the publish command finishes
+# Try waiting 3 minutes until the package version is available
+for _i in {1..6}; do
+    curl -sf "${PACKAGE_DEFINITION_URL}" &> /dev/null && break;
+    echo "Package ${PACKAGE_NAME} version ${PACKAGE_VERSION} is not available yet."
+    echo "Will retry in 30 seconds."
+    sleep 30;
+done
+
+# Get the tarball URL from the package definition on NPM
+TARBALL_URL=$(curl -sf "${PACKAGE_DEFINITION_URL}" | jq -r '.dist.tarball') \
+    || { echo "Package ${PACKAGE_NAME} version ${PACKAGE_VERSION} is not available."; exit 1; };
+
+# Calculate the SHA256 hash of the tarball
+SHA256=$(curl -sf "${TARBALL_URL}" | sha256sum | cut -d " " -f 1)
+
+# Replace the URL and the hash in the formula definition
+# We have to use `@` as the sed command separator because URLs contain `/`
+sed -i.bak -e "s@  url .*@  url \"${TARBALL_URL}\"@" "${PACKAGE_NAME}.rb"
+sed -i.bak -e "s@  sha256 .*@  sha256 \"${SHA256}\"@" "${PACKAGE_NAME}.rb"
+rm -rf "${PACKAGE_NAME}.rb.bak"

--- a/.github/workflows/pr_toolkit.yaml
+++ b/.github/workflows/pr_toolkit.yaml
@@ -1,0 +1,23 @@
+# For more info see: https://github.com/apify/pull-request-toolkit-action/
+name: Apify PR toolkit
+
+on:
+  pull_request:
+    branches:
+      - master
+    types: ['opened', 'reopened', 'synchronize', 'labeled', 'unlabeled', 'edited', 'ready_for_review'] # The first 3 are default.
+
+concurrency: # This is to make sure that it's executed only for the most recent changes of PR.
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  apify-pr-toolkit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: run pull-request-toolkit action
+        uses: apify/pull-request-toolkit-action@main
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          org-token: ${{ secrets.PULL_REQUEST_TOOLKIT_ACTION_GITHUB_TOKEN }}
+          zenhub-token: ${{ secrets.PULL_REQUEST_TOOLKIT_ACTION_ZENHUB_TOKEN }}

--- a/.github/workflows/update_formula.yaml
+++ b/.github/workflows/update_formula.yaml
@@ -1,0 +1,79 @@
+name: Update formula
+
+on:
+  workflow_dispatch:
+    inputs:
+      package:
+        description: 'Package / formula name'
+        required: true
+        type: string
+      version:
+        description: 'Package version'
+        required: true
+        type: string
+
+  workflow_call:
+    inputs:
+      package:
+        description: 'Package / formula name'
+        required: true
+        type: string
+      version:
+        description: 'Package version'
+        required: true
+        type: string
+
+jobs:
+  test-updated-formula:
+    name: Test updated formula
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Update package in formula
+      run: ./.github/scripts/update_formula.sh ${{ github.event.inputs.package }} ${{ github.event.inputs.version }}
+
+    - name: Set up Homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+
+    - name: Test updated formula
+      run: |
+        set -o errexit
+        export HOMEBREW_NO_AUTO_UPDATE=1
+        export HOMEBREW_NO_ANALYTICS=1
+        export HOMEBREW_NO_INSTALL_CLEANUP=1
+
+        # Install the updated formula
+        # (due to setup-homebrew magic, the working directory is also considered as a tap, so no need to copy around the updated formula file)
+        brew install $GITHUB_REPOSITORY/${{ github.event.inputs.package }}
+
+        # Run the formula tests
+        brew test ${{ github.event.inputs.package }}
+
+  update-formula:
+    name: Update formula and commit result
+    needs: [test-updated-formula]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Update package version and commit result
+      run: |
+        set -o errexit
+
+        ./.github/scripts/update_formula.sh ${{ github.event.inputs.package }} ${{ github.event.inputs.version }}
+
+        git config user.name 'GitHub Actions'
+        git config user.email 'github-actions[bot]@users.noreply.github.com'
+        git add Formula/${{ github.event.inputs.package }}.rb
+        git commit -m "Updating \`${{ github.event.inputs.package }}\` to version \`${{ github.event.inputs.version }}\`"
+        git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.vscode
+.idea
+.DS_Store

--- a/Formula/apify-cli.rb
+++ b/Formula/apify-cli.rb
@@ -1,0 +1,22 @@
+require "language/node"
+
+class ApifyCli < Formula
+  desc "Apify command-line interface"
+  homepage "https://docs.apify.com/cli"
+  url "https://registry.npmjs.org/apify-cli/-/apify-cli-0.14.1.tgz"
+  sha256 "312b8fe810ae4a224908410df9f9bf18c1e613de6b698d8ea1bc86f1fb59662a"
+  license "Apache-2.0"
+
+  depends_on "node@16"
+
+  def install
+    system "npm", "install", *Language::Node.std_npm_install_args(libexec)
+    # We have to replace the shebang in the main executable from "/usr/bin/env node" to point to the keg-only node@16
+    inreplace "#{libexec}/lib/node_modules/apify-cli/src/bin/run", "/usr/bin/env node", "#{Formula["node@16"].opt_bin}/node"
+    bin.install_symlink Dir["#{libexec}/bin/*"]
+  end
+
+  test do
+    assert_match "apify-cli/#{version}", shell_output("#{bin}/apify --version")
+  end
+end

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Apify Homebrew Tap
+
+## What is Homebrew?
+
+A package manager for macOS (or Linux), see more at <https://brew.sh>.
+
+## What is a Tap?
+
+A third-party (in relation to Homebrew) repository
+providing installable packages (formulae) on macOS and Linux.
+
+See more at <https://docs.brew.sh/Taps>
+
+## How do I install packages from here?
+
+```sh
+brew install apify/tap/<PACKAGE_NAME>
+```
+
+You can also only add the tap which makes formulae within it
+available in search results (`brew search` output):
+
+```sh
+brew tap apify/tap
+```
+
+## What packages are available?
+
+Currently, only the [Apify CLI](https://docs.apify.com/apify-cli) is available in this tap:
+
+```sh
+brew install apify/tap/apify-cli
+
+apify create my-first-actor
+```


### PR DESCRIPTION
This adds the Apify CLI to our new Homebrew tap. It will be installable by `brew install apify/tap/apify-cli`.

It depends on `node@16`, so that users won't have to install Node themselves, but it also won't pollute their default `PATH` with Node.js on its own. It also patches the `src/bin/run` file in `apify-cli` to use the correct `node@16` shebang instead of `/usr/bin/env node`, so the CLI will work even for people who don't have Node.js installed globally.

This PR also adds a workflow which automatically updates the formula with a new package version from NPM (and tests it). We should call it from the release process of Apify CLI, I will send a PR there soon.