### PR TITLE
fix formula test

### DIFF
--- a/Formula/apify-cli.rb
+++ b/Formula/apify-cli.rb
@@ -44,7 +44,7 @@ class ApifyCli < Formula
     # Test that the Apify CLI is at all installed and working
     assert_match "apify-cli/#{version}", shell_output("#{bin}/apify --version")
     # Test that the CLI can initialize a new actor
-    system "#{bin}/apify", "init", "testing-actor"
+    system "#{bin}/apify", "init", "-y", "testing-actor"
     assert_predicate testpath/".actor/actor.json", :exist?
   end
 end


### PR DESCRIPTION
CLI 0.19 now checks if init command is executed in empty folder and prompts the user for confirmation. The test now uses `-y` to get around this.